### PR TITLE
Update Adapptr docs for serverless migration

### DIFF
--- a/Adapptr/APIMigration.md
+++ b/Adapptr/APIMigration.md
@@ -1,0 +1,32 @@
+# Adapptr API Migration
+
+As part of our commitment to improve the Adapptr product, we are migrating the API to serverless deployments. By doing this, we are able to better manage resources and migrate clients to an enhanced infrastructure which offers faster and even more efficient file runs.
+
+In order to support this for our Adapptr clients, an amendment to the used API endpoints is required. Clients would need to replace the endpoint URLs previously confirmed by FundApps with new ones, similar to the example you can find below. We suggest clients amend their endpoints ASAP in preparation for the changeover in order to allow for testing, as we will be retiring the legacy architecture and as a result, clients would be mandated at that point to migrate for successful and continued Adapptr usage.
+
+## ABC Ltd. Example
+
+For example, a client named **ABC Ltd**. is able to access their Rapptr service at `https://abc.fundapps.co`.  
+Their current **base Adapptr URL** of `https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod`.
+
+As per the [official docs](../README.md), **ABC's** endpoints currently resemble the below:
+
+`BaseUrl = https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod` + `/rest/api/v1` + `/configuration/dataproviders/{providerId}/credentials`  
+`BaseUrl = https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod` + `/rest/api/v1` + `/nomenclatures`  
+`BaseUrl = https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod` + `/rest/api/v1` + `/task/positions`  
+`BaseUrl = https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod` + `/rest/api/v1` + `/task/positions/without-enrichment`  
+`BaseUrl = https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod` + `/rest/api/v1` + `/task/{taskId}/status`  
+etc.
+
+**ABC**'s Rapptr service URL remains the same after migration.  
+Their their new **base Adapptr URL** however is `https://abc-svc.fundapps.co`.  
+The new endpoints are the same as above, except for replacing `/rest/api/v1/` with `/api/adapptr/v1/`, as shown below:
+
+`BaseUrl = https://abc-svc.fundapps.co` + `/api/adapptr/v1` + `/configuration/dataproviders/{providerId}/credentials`  
+`BaseUrl = https://abc-svc.fundapps.co` + `/api/adapptr/v1` + `/nomenclatures`  
+`BaseUrl = https://abc-svc.fundapps.co` + `/api/adapptr/v1` + `/task/positions`  
+`BaseUrl = https://abc-svc.fundapps.co` + `/api/adapptr/v1` + `/task/positions/without-enrichment`  
+`BaseUrl = https://abc-svc.fundapps.co` + `/api/adapptr/v1` + `/task/{taskId}/status`  
+etc.
+
+ℹ A [Sample Postman collection](Sample-PostmanCollections/New_Adapptr.postman_collection) is available to use in your migration efforts. Please ignore the `Adapptr Integrations` folder if you are not signed up to use this functionality.

--- a/Adapptr/Sample-Code&Scripts/C#/DataProviderCredentials.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/DataProviderCredentials.cs
@@ -14,10 +14,10 @@ namespace FundAppsScripts.Scripts
         {
             _adapptrConfig = adapptrConfig;
         }
-        
+
         // if you need to use Bloomberg as a data provider the implementation given below is not applicable
         // please refer to the documentation for more info: https://github.com/fundapps/api-examples#data-provider-credentials-post-restapiv1configurationdataprovidersprovideridcredentials
-       
+
         public void PostDataPrividerCredentials()
         {
             var baseUrl = _adapptrConfig.BaseUrl;
@@ -26,7 +26,7 @@ namespace FundAppsScripts.Scripts
             // your FundApps environment name
             var clientEnvironmentSubDomain = "";
 
-            //data providers ids can be obtained from a GET /rest/api/v1/dataproviders. You will need to fill Id with the value of the data vendor you are using
+            //data providers ids can be obtained from a GET /api/adapptr/v1/dataproviders. You will need to fill Id with the value of the data vendor you are using
             var refinitivId = _adapptrConfig.RefinitivConfig.Id;
             // set your username
             var refinitivUsername = _adapptrConfig.RefinitivConfig.Username;
@@ -42,7 +42,7 @@ namespace FundAppsScripts.Scripts
             };
 
             // make the HTTP POST request with the market data provider id as route parameter
-            var request = new RestRequest($"/rest/api/v1/dataproviders/{refinitivId}/credentials", Method.POST);
+            var request = new RestRequest($"/api/adapptr/v1/dataproviders/{refinitivId}/credentials", Method.POST);
 
             // add json body to the request
             request.AddJsonBody(new

--- a/Adapptr/Sample-Code&Scripts/C#/TaskStatus.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/TaskStatus.cs
@@ -20,7 +20,7 @@ namespace FundAppsScripts.Scripts
             taskId = taskId ?? "";
 
             //Example using RestSharp (https://github.com/restsharp/RestSharp)
-   
+
             //Create a client which will connect to the HTTPS endpoint with the API credentials you have been provided
             var client = new RestClient(baseUrl)
             {
@@ -28,7 +28,7 @@ namespace FundAppsScripts.Scripts
             };
 
             // make the HTTP GET request with the taskId as route parameter
-            var request = new RestRequest($"/rest/api/v1/task/{taskId}/status", Method.GET);
+            var request = new RestRequest($"/api/adapptr/v1/task/{taskId}/status", Method.GET);
 
             // add header with the rapptr environment
             request.AddHeader("X-Client-Environment", clientEnvironmentSubDomain);

--- a/Adapptr/Sample-Code&Scripts/C#/UploadPositions.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/UploadPositions.cs
@@ -19,12 +19,12 @@ namespace FundAppsScripts.Scripts
             var pathToFile = "";
             // the snapshot date of your positions in the format yyyy-MM-dd
             var snapshotDate = DateTime.Today.ToString("yyyy-MM-dd");
-            
+
             // if dataProvider = 1 it means that the dataProvider is Refinitiv
             // if dataProvider = 2 it means that the dataProvider is Bloomberg
             // plese refer to the documentation for more info: https://github.com/mmitushevskiMelon/api-examples#post-restapiv1taskpositions
             var dataProvider = 1;
-            
+
             //Example using RestSharp (https://github.com/restsharp/RestSharp)
 
             //Create a client which will connect to the HTTPS endpoint with the API credentials you have been provided
@@ -34,17 +34,17 @@ namespace FundAppsScripts.Scripts
             };
 
             // make the HTTP POST request
-            var request = new RestRequest($"/rest/api/v1/task/positions", Method.POST);
+            var request = new RestRequest($"/api/adapptr/v1/task/positions", Method.POST);
 
             // add body params to the request
             request.AddFile("positions", pathToFile, "text/csv");
             request.AddParameter("snapshotDate", snapshotDate);
             request.AddParameter("dataProvider", dataProvider);
-            
+
             // add header with the rapptr environment
             request.AddHeader("X-Client-Environment", clientEnvironmentSubDomain);
             request.AddHeader("Content-Type", "multipart/form-data");
-            
+
             var response = client.Execute<TaskProfileResponse>(request);
 
             // if response comes back with a 200 status, then as task for the positions file was created successfully

--- a/Adapptr/Sample-Code&Scripts/C#/UploadPositions.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/UploadPositions.cs
@@ -22,7 +22,7 @@ namespace FundAppsScripts.Scripts
 
             // if dataProvider = 1 it means that the dataProvider is Refinitiv
             // if dataProvider = 2 it means that the dataProvider is Bloomberg
-            // plese refer to the documentation for more info: https://github.com/mmitushevskiMelon/api-examples#post-restapiv1taskpositions
+            // plese refer to the documentation for more info: https://github.com/fundapps/TechDocs#post-restapiv1taskpositions
             var dataProvider = 1;
 
             //Example using RestSharp (https://github.com/restsharp/RestSharp)

--- a/Adapptr/Sample-Code&Scripts/C#/UploadPositionsWithoutEnrichment.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/UploadPositionsWithoutEnrichment.cs
@@ -19,12 +19,12 @@ namespace FundAppsScripts.Scripts
             var pathToFile = "";
             // the snapshot date of your positions in the format yyyy-MM-dd
             var snapshotDate = DateTime.Today.ToString("yyyy-MM-dd");
-            
+
             // if the file format type is not specified then the format will be 2 by default
             // 2 means Consensys
             // please refer to the documentation for more info: https://github.com/fundapps/api-examples#available-nomenclatures-get-restapiv1nomenclatures
             var format = "2";
-            
+
             //Example using RestSharp (https://github.com/restsharp/RestSharp)
 
             //Create a client which will connect to the HTTPS endpoint with the API credentials you have been provided
@@ -34,17 +34,17 @@ namespace FundAppsScripts.Scripts
             };
 
             // make the HTTP POST request
-            var request = new RestRequest($"/rest/api/v1/task/positions/without-enrichment", Method.POST);
+            var request = new RestRequest($"/api/adapptr/v1/task/positions/without-enrichment", Method.POST);
 
             // add body params to the request
             request.AddFile("positions", pathToFile, "text/csv");
             request.AddParameter("snapshotDate", snapshotDate);
             request.AddParameter("format", format);
-            
+
             // add header with the rapptr environment
             request.AddHeader("X-Client-Environment", clientEnvironmentSubDomain);
             request.AddHeader("Content-Type", "multipart/form-data");
-            
+
             var response = client.Execute<TaskProfileResponse>(request);
 
             // if response comes back with a 200 status, then as task for the positions file was created successfully

--- a/Adapptr/Sample-Code&Scripts/Powershell/check-task-status.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/check-task-status.ps1
@@ -35,7 +35,7 @@ function API-GET {
         }
         else{
             throw
-        }      
+        }
     }
 }
 
@@ -43,7 +43,7 @@ function Get-Status {
     Param ($APIUri, $User, $Password, $TaskId, $ClientEnvironment)
 
     $params = @{
-        Uri = "$APIUri/rest/api/v1/task/$TaskId/status"
+        Uri = "$APIUri/api/adapptr/v1/task/$TaskId/status"
         User = $User
         Password = $Password
         ClientEnvironment = $ClientEnvironment

--- a/Adapptr/Sample-Code&Scripts/Powershell/post-data-provider-credentials.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/post-data-provider-credentials.ps1
@@ -31,7 +31,7 @@ function API-Post-Json {
             $reader.DiscardBufferedData()
             $responseBody = $reader.ReadToEnd();
 
-            Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+            Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
             Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
             Write-Host $_.ErrorDetails.Message
             Write-Host $responseBody
@@ -44,10 +44,10 @@ function API-Post-Json {
 
 function Update-Credentials {
     Param ($APIUri, $User, $Password, $DataProviderId, $DataProviderUsername, $DataProviderPassword, $ClientEnvironment)
-    Write-Host ("$APIUri/rest/api/v1/configuration/dataproviders/$DataProviderId/credentials")
+    Write-Host ("$APIUri/api/adapptr/v1/configuration/dataproviders/$DataProviderId/credentials")
 
     $params = @{
-        Uri = "$APIUri/rest/api/v1/configuration/dataproviders/$DataProviderId/credentials"
+        Uri = "$APIUri/api/adapptr/v1/configuration/dataproviders/$DataProviderId/credentials"
         User = $User
         Password = $Password
         Data = @{

--- a/Adapptr/Sample-Code&Scripts/Powershell/upload-positions-without-enrichment.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/upload-positions-without-enrichment.ps1
@@ -91,7 +91,7 @@ function Import-File {
 
 function Import-Positions {
     Param ($APIUri, $User, $Password, $File, $ClientEnvironment)
-    Import-File -User $User -Password $Password -File $File -Uri ($APIUri + "/rest/api/v1/task/positions/without-enrichment") -ClientEnvironment $ClientEnvironment
+    Import-File -User $User -Password $Password -File $File -Uri ($APIUri + "/api/adapptr/v1/task/positions/without-enrichment") -ClientEnvironment $ClientEnvironment
 }
 
 Write-Host "Done"

--- a/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
@@ -90,7 +90,7 @@ function Import-File {
 
 function Import-Positions {
     Param ($APIUri, $User, $Password, $File, $ClientEnvironment)
-    Import-File -User $User -Password $Password -File $File -Uri ($APIUri + "/rest/api/v1/task/positions") -ClientEnvironment $ClientEnvironment
+    Import-File -User $User -Password $Password -File $File -Uri ($APIUri + "/api/adapptr/v1/task/positions") -ClientEnvironment $ClientEnvironment
 }
 
 Write-Host "Done"

--- a/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
@@ -12,16 +12,16 @@ function API-Post {
 
     $fileBytes = [System.IO.File]::ReadAllBytes($File);
     $fileEnc = [System.Text.Encoding]::GetEncoding('UTF-8').GetString($fileBytes);
-    $boundary = [System.Guid]::NewGuid().ToString(); 
+    $boundary = [System.Guid]::NewGuid().ToString();
     $LF = "`r`n";
     $snapshotDate = Get-Date -Format "yyyy-MM-dd";
-    
+
 
     # plese refer to the documentation for more information on parameters that you can use: https://github.com/fundapps/TechDocs#post-restapiv1taskpositions
 
     $dataProvider = "1";
-    
-    $bodyLines = ( 
+
+    $bodyLines = (
         "--$boundary",
         "Content-Disposition: form-data; name=`"snapshotDate`"$LF",
         "$snapshotDate$LF",
@@ -32,7 +32,7 @@ function API-Post {
         "Content-Disposition: form-data; name=`"positions`"; filename=`"positions.csv`"",
         "Content-Type: application/octet-stream$LF",
         $fileEnc,
-        "--$boundary--$LF" 
+        "--$boundary--$LF"
     ) -join $LF
 
     $params = @{
@@ -44,7 +44,7 @@ function API-Post {
     }
 
     try {
-        Invoke-RestMethod @params 
+        Invoke-RestMethod @params
     }
     catch [System.Net.WebException]{
         if($_.Exception.Response){
@@ -53,8 +53,8 @@ function API-Post {
             $reader.BaseStream.Position = 0
             $reader.DiscardBufferedData()
             $responseBody = $reader.ReadToEnd();
-    
-            Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+
+            Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
             Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
             Write-Host $_.ErrorDetails.Message
             Write-Host $responseBody

--- a/Adapptr/Sample-PostmanCollections/Adapptr.postman_collection
+++ b/Adapptr/Sample-PostmanCollections/Adapptr.postman_collection
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7902048e-b0f5-4cf9-93f3-01caf0d7df30",
+		"_postman_id": "365d376f-97f8-43f1-9b4f-b5df467eef39",
 		"name": "Adapptr",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "3279036"
@@ -688,13 +688,13 @@
 					]
 				},
 				"url": {
-					"raw": "{{BaseUrl}}/api/adapptr/v1/task/positions",
+					"raw": "{{BaseUrl}}/rest/api/v1/task/positions",
 					"host": [
 						"{{BaseUrl}}"
 					],
 					"path": [
+						"rest",
 						"api",
-						"adapptr",
 						"v1",
 						"task",
 						"positions"

--- a/Adapptr/Sample-PostmanCollections/Adapptr.postman_collection
+++ b/Adapptr/Sample-PostmanCollections/Adapptr.postman_collection
@@ -1,0 +1,944 @@
+{
+	"info": {
+		"_postman_id": "7902048e-b0f5-4cf9-93f3-01caf0d7df30",
+		"name": "Adapptr",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3279036"
+	},
+	"item": [
+		{
+			"name": "Rapptr",
+			"item": [
+				{
+					"name": "Upload Positions XML",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "password",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "username",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "positions",
+									"type": "file",
+									"src": "///FS-SF01/RDSusers$/mihristov/Desktop/test.xml"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/check",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"check"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check Rapptr Status",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "password",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "username",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/result/:id",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"result",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "6fc60e00-d6d8-4460-919b-ae3000c0dea9"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get JWT",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*.fundapps.co/jwtbearer/token",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"jwtbearer",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "XSD",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/xsd",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"xsd"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Refinitiv",
+			"item": [
+				{
+					"name": "GetAssetCategories",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Search/GetAssetCategories",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Search",
+								"GetAssetCategories"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesShareholderDisclosure",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"CUSIP\",\r\n            \"Par Value\",\r\n            \"Nominal Value\",\r\n            \"Nominal Value Currency\",\r\n            \"Total Issued Share Capital - Currency\",\r\n            \"Asset Type\",\r\n            \"ISIN\",\r\n            \"Market MIC\",\r\n            \"Security Long Name\",\r\n            \"Issuer Name\",\r\n            \"Currency Code\",\r\n            \"Close Price\",\r\n            \"Issuer PermID\",\r\n            \"MIC List\",\r\n            \"Notional Amount\",\r\n            \"Lot Size\",\r\n            \"Strike Price\",\r\n            \"Total Amount Outstanding\",\r\n            \"Conversion Ratio\",\r\n            \"Delta\",\r\n            \"Ticker\",\r\n            \"Shares Amount\",\r\n            \"Round Lot Size\",\r\n            \"Voting Rights Per Share\",\r\n            \"Country of Incorporation\",\r\n            \"Market Capitalization\",\r\n            \"Total Shares - Treasury\",\r\n            \"Total Shares - Outstanding\",\r\n            \"Total Voting Rights - Default\",\r\n            \"Total Voting Shares - Default\",\r\n            \"Maturity Date\",\r\n            \"Country of Issuance\",\r\n            \"SEC Section 12\",\r\n            \"Security Description\",\r\n            \"Entity LEI\",\r\n            \"Share Class\",\r\n            \"Bond Future Modified Duration\",\r\n            \"Debt Outstanding - Total Amount Outstanding\",\r\n            \"Convertible Redemption Type\",\r\n            \"GICS Industry Code\",\r\n            \"Expiration Date\",\r\n            \"Underlying RIC\",\r\n            \"Covered Bond Flag\",\r\n            \"Asset Ratio Against\",\r\n            \"Asset Ratio For\",\r\n            \"Convertible Effective Date\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Convertible Flag\",\r\n            \"Convertible Sub Type Code\",\r\n            \"When Issued Flag\",\r\n            \"Conversion Fixed Shares\",\r\n            \"Method of Delivery\",\r\n            \"Exercise Style\",\r\n            \"Put Call Flag\",\r\n            \"Exchange Listed Flag\",\r\n            \"Exchange Code\",\r\n            \"Industry Description\",\r\n            \"Industry Sector Code\",\r\n            \"Industry Sector Description\",\r\n            \"Industry Sub-Description\",\r\n            \"Industry Sub-Sector Code\",\r\n            \"Industry Sub-Sector Description\",\r\n            \"Parent Immediate Industry Sector\",\r\n            \"Parent Immediate Industry Description\",\r\n            \"Industry Classification Benchmark Code\",\r\n            \"Industry Classification Benchmark Description\",\r\n            \"Parent Industry Description\",\r\n            \"Asset Status Description\",\r\n            \"Underlying ISIN\",\r\n            \"Total Issued Share Capital\",\r\n            \"Domicile\",\r\n            \"Executable Ratio Shares Held\",\r\n            \"Executable Ratio Resulting Shares\",\r\n            \"Total Voting Rights - Treasury\",\r\n            \"Security Long Description\",\r\n            \"Total Voting Shares - Treasury\",\r\n            \"GICS Industry Description Code\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n  {\r\n    \"Identifier\": \"KYG9830T1067\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"ES0113900J37\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"CH0108503795\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"TSLA.OQ\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"BSANTANDER.SN\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"BE0974288202\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"IT0000336518\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"PIN.UNL\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"FR0000031122\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"GB00B019KW72\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"GB00B03MLX29\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"US0378331005\",\r\n    \"IdentifierType\": \"Isin\"\r\n  }\r\n],\r\n            \"ValidationOptions\":{\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesCombined",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"CUSIP\",\r\n            \"Par Value\",\r\n            \"Nominal Value\",\r\n            \"Nominal Value Currency\",\r\n            \"Total Issued Share Capital - Currency\",\r\n            \"Asset Type\",\r\n            \"ISIN\",\r\n            \"Market MIC\",\r\n            \"Security Long Name\",\r\n            \"Issuer Name\",\r\n            \"Currency Code\",\r\n            \"Close Price\",\r\n            \"Issuer PermID\",\r\n            \"MIC List\",\r\n            \"Notional Amount\",\r\n            \"Lot Size\",\r\n            \"Strike Price\",\r\n            \"Total Amount Outstanding\",\r\n            \"Conversion Ratio\",\r\n            \"Delta\",\r\n            \"Ticker\",\r\n            \"Shares Amount\",\r\n            \"Round Lot Size\",\r\n            \"Voting Rights Per Share\",\r\n            \"Country of Incorporation\",\r\n            \"Market Capitalization\",\r\n            \"Total Shares - Treasury\",\r\n            \"Total Shares - Outstanding\",\r\n            \"Total Voting Rights - Default\",\r\n            \"Total Voting Shares - Default\",\r\n            \"Maturity Date\",\r\n            \"Country of Issuance\",\r\n            \"SEC Section 12\",\r\n            \"Security Description\",\r\n            \"Entity LEI\",\r\n            \"Share Class\",\r\n            \"Bond Future Modified Duration\",\r\n            \"Debt Outstanding - Total Amount Outstanding\",\r\n            \"Convertible Redemption Type\",\r\n            \"GICS Industry Code\",\r\n            \"Expiration Date\",\r\n            \"Underlying RIC\",\r\n            \"Covered Bond Flag\",\r\n            \"Asset Ratio Against\",\r\n            \"Asset Ratio For\",\r\n            \"Convertible Effective Date\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Convertible Flag\",\r\n            \"Convertible Sub Type Code\",\r\n            \"When Issued Flag\",\r\n            \"Conversion Fixed Shares\",\r\n            \"Method of Delivery\",\r\n            \"Exercise Style\",\r\n            \"Put Call Flag\",\r\n            \"Exchange Listed Flag\",\r\n            \"Exchange Code\",\r\n            \"Industry Description\",\r\n            \"Industry Sector Code\",\r\n            \"Industry Sector Description\",\r\n            \"Industry Sub-Description\",\r\n            \"Industry Sub-Sector Code\",\r\n            \"Industry Sub-Sector Description\",\r\n            \"Parent Immediate Industry Sector\",\r\n            \"Parent Immediate Industry Description\",\r\n            \"Industry Classification Benchmark Code\",\r\n            \"Industry Classification Benchmark Description\",\r\n            \"Parent Industry Description\",\r\n            \"Asset Status Description\",\r\n            \"Underlying ISIN\",\r\n            \"Total Issued Share Capital\",\r\n            \"Domicile\",\r\n            \"Executable Ratio Shares Held\",\r\n            \"Executable Ratio Resulting Shares\",\r\n            \"Total Voting Rights - Treasury\",\r\n            \"Last Updated Open Interest\",\r\n            \"Security Long Description\",\r\n            \"Share Delivery Code\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n                {\r\n                    \"Identifier\": \"US98421U1088\",\r\n                    \"IdentifierType\": \"Isin\"\r\n                }\r\n            ],\r\n            \"ValidationOptions\": {\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesPositionLimits",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"Asset Type\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Underlying RIC\",\r\n            \"Underlying ISIN\",\r\n            \"Currency Code\",\r\n            \"Security Description\",\r\n            \"Close Price\",\r\n            \"Market MIC\",\r\n            \"Exchange Code\",\r\n            \"Asset Status Description\",\r\n            \"Ticker\",\r\n            \"Lot Size\",\r\n            \"Expiration Date\",\r\n            \"Delta\",\r\n            \"Method of Delivery\",\r\n            \"Last Updated Open Interest\",\r\n            \"Put Call Flag\",\r\n            \"Security Long Description\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n                {\r\n                    \"Identifier\": \"BYW4289\",\r\n                    \"IdentifierType\": \"Sedol\"\r\n                },\r\n                {\r\n                    \"Identifier\": \"BN2BD13\",\r\n                    \"IdentifierType\": \"Sedol\"\r\n                }\r\n            ],\r\n            \"ValidationOptions\":{\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Request Token",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"Credentials\": {\r\n        \"Username\": \"9008961\",\r\n        \"Password\": \"JIN0Xd3A\"\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Authentication/RequestToken",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Authentication",
+								"RequestToken"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetGicsIndustryClassifications",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Search/GetGicsIndustryClassifications ",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Search",
+								"GetGicsIndustryClassifications "
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "oauth2",
+				"oauth2": [
+					{
+						"key": "headerPrefix",
+						"value": "Token",
+						"type": "string"
+					},
+					{
+						"key": "addTokenTo",
+						"value": "header",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"pm.sendRequest({",
+							"    url: pm.variables.get(\"RefinitivBaseUrl\") + '/RestApi/v1/Authentication/RequestToken',",
+							"    method: 'POST',",
+							"    header: {",
+							"        'content-type': 'application/json'",
+							"    },",
+							"    body: {",
+							"        mode: 'raw',",
+							"        raw: JSON.stringify({",
+							"          \"Credentials\": {",
+							"            \"Username\": pm.variables.get(\"RefinitivUsername\"),",
+							"            \"Password\": pm.variables.get(\"RefinitivPassword\")",
+							"          }",
+							"        })",
+							"    }",
+							"}, function (err, res) {",
+							"    pm.variables.set(\"RefinitivToken\", res.json().value);",
+							"});"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Adapptr Integrations",
+			"item": [
+				{
+					"name": "Convert - Large",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "storageFileName",
+									"value": "2d808d79fc31442b8f2f0a914d209558-hassana format.xls",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/large/convert",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"large",
+								"convert"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Ping",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/ping",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"ping"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Pre Signed Url",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/large/pre-signed-url?fileName=Hassana Format.XLS",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"large",
+								"pre-signed-url"
+							],
+							"query": [
+								{
+									"key": "fileName",
+									"value": "Hassana Format.XLS"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Upload File Using PreSignedUrl",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": "///FS-SF01/RDSusers$/mihristov/Downloads/adapptr-data/Hassana Format.XLS"
+							}
+						},
+						"url": {
+							"raw": "https://adapptr-integrations-localhost.s3-eu-west-1.amazonaws.com/client-files/2d808d79fc31442b8f2f0a914d209558-hassana%20format.xls?X-Amz-Expires=1800&X-Amz-Security-Token=IQoJb3JpZ2luX2VjELH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJIMEYCIQCHN%2FCbnr8qQ1avIC6TbuCo4mx0FP1fho%2BLFDgiQTe0zQIhAK%2Ftwn5oUbfM6NqTgutkAnPpqcjYKPJ581OQzMtOjOhSKqEDCLr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQARoMNjg0Njc4Njk4NDQzIgymg%2Fmgr0SkQGs00Vkq9QIlIKCJsPvMGfA2bbEq1SRERF34BEx4CxKS0PQfC8APqRtS%2BitkIJzgdDzWR61sul5wVP7CtjHFCUPNRtyWcoFI8klViAe3SsCSQ0n9QBfMSfWUlM%2F797FljzwijWRQ8xml8EumOkckh%2BWUNbCFii0LchAjQUAulZyUlPrbTmUpLUV50Fo%2BNXtrGXqR743nSsoJApFlneOSTfx3AN5XPYNk8nswVsGD1OSuzmSiljmKith1aYW4LHE85jZitDCemPabv6IQe6lSJpVK2A9aTNWnT7pIN25wuyMWRBDPpHXwv8Lex5zqdbqQ%2BzpzTgODxkXr2GDkQCyqDwxk%2BZctqM%2BddTKhPYydVtIkgUDqGj%2BsiARW2JXUAeZuj6oSMYjDsvTPEX4e%2FQcsuH7LB8n8fo4XW%2Bv3MJ6Ytl8EtYLiXxNdLyOxm9blJleWU%2BzP6D%2BtMoQK6gBygzkKmJfo6ONnDW53f2SNCo7F7V6z3YyTgxXOBGx1%2FO07MIT8344GOqUBSWI7oficGtv3i9L%2BvlLW9G7uwqbyYCuKqrcHUGWGCWibK5zcMp6byaheabyDqwRs%2BOXT7NzgqvGDQFkIRg4gT0XptclV9hFclXT5nyoR3nV8wVslLi1Nh6NQ8GZfNkzunAG%2F11HdSlHsPC%2FJO13Q0dC4ak12d45Yk7Ci4RdysarVZz42TkrgpzuvLGwA%2BLjz4qsPlncFptq9Ngb5I7HNHDlFZ3F%2B&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAZ62QH2XFZFLGTJXY/20220107/eu-west-1/s3/aws4_request&X-Amz-Date=20220107T084956Z&X-Amz-SignedHeaders=host&X-Amz-Signature=eed68d46adc1a55d36c7d1cfcef689c73b1094506f176d4136d7451e84d21287",
+							"protocol": "https",
+							"host": [
+								"adapptr-integrations-localhost",
+								"s3-eu-west-1",
+								"amazonaws",
+								"com"
+							],
+							"path": [
+								"client-files",
+								"2d808d79fc31442b8f2f0a914d209558-hassana%20format.xls"
+							],
+							"query": [
+								{
+									"key": "X-Amz-Expires",
+									"value": "1800"
+								},
+								{
+									"key": "X-Amz-Security-Token",
+									"value": "IQoJb3JpZ2luX2VjELH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJIMEYCIQCHN%2FCbnr8qQ1avIC6TbuCo4mx0FP1fho%2BLFDgiQTe0zQIhAK%2Ftwn5oUbfM6NqTgutkAnPpqcjYKPJ581OQzMtOjOhSKqEDCLr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQARoMNjg0Njc4Njk4NDQzIgymg%2Fmgr0SkQGs00Vkq9QIlIKCJsPvMGfA2bbEq1SRERF34BEx4CxKS0PQfC8APqRtS%2BitkIJzgdDzWR61sul5wVP7CtjHFCUPNRtyWcoFI8klViAe3SsCSQ0n9QBfMSfWUlM%2F797FljzwijWRQ8xml8EumOkckh%2BWUNbCFii0LchAjQUAulZyUlPrbTmUpLUV50Fo%2BNXtrGXqR743nSsoJApFlneOSTfx3AN5XPYNk8nswVsGD1OSuzmSiljmKith1aYW4LHE85jZitDCemPabv6IQe6lSJpVK2A9aTNWnT7pIN25wuyMWRBDPpHXwv8Lex5zqdbqQ%2BzpzTgODxkXr2GDkQCyqDwxk%2BZctqM%2BddTKhPYydVtIkgUDqGj%2BsiARW2JXUAeZuj6oSMYjDsvTPEX4e%2FQcsuH7LB8n8fo4XW%2Bv3MJ6Ytl8EtYLiXxNdLyOxm9blJleWU%2BzP6D%2BtMoQK6gBygzkKmJfo6ONnDW53f2SNCo7F7V6z3YyTgxXOBGx1%2FO07MIT8344GOqUBSWI7oficGtv3i9L%2BvlLW9G7uwqbyYCuKqrcHUGWGCWibK5zcMp6byaheabyDqwRs%2BOXT7NzgqvGDQFkIRg4gT0XptclV9hFclXT5nyoR3nV8wVslLi1Nh6NQ8GZfNkzunAG%2F11HdSlHsPC%2FJO13Q0dC4ak12d45Yk7Ci4RdysarVZz42TkrgpzuvLGwA%2BLjz4qsPlncFptq9Ngb5I7HNHDlFZ3F%2B"
+								},
+								{
+									"key": "X-Amz-Algorithm",
+									"value": "AWS4-HMAC-SHA256"
+								},
+								{
+									"key": "X-Amz-Credential",
+									"value": "ASIAZ62QH2XFZFLGTJXY/20220107/eu-west-1/s3/aws4_request"
+								},
+								{
+									"key": "X-Amz-Date",
+									"value": "20220107T084956Z"
+								},
+								{
+									"key": "X-Amz-SignedHeaders",
+									"value": "host"
+								},
+								{
+									"key": "X-Amz-Signature",
+									"value": "eed68d46adc1a55d36c7d1cfcef689c73b1094506f176d4136d7451e84d21287"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Convert",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "positions",
+									"type": "file",
+									"src": "///FS-SF01/RDSusers$/mihristov/Downloads/adapptr-data/Hassana Format.XLS"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/convert",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"convert"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "basic",
+				"basic": [
+					{
+						"key": "password",
+						"value": "password",
+						"type": "string"
+					},
+					{
+						"key": "username",
+						"value": "username",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Upload Positions",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "positions",
+							"type": "file",
+							"src": "///FS-SF01/RDSusers$/mihristov/Desktop/Case 3.csv"
+						},
+						{
+							"key": "snapshotDate",
+							"value": "2022-03-30",
+							"type": "text"
+						},
+						{
+							"key": "services",
+							"value": "2",
+							"type": "text"
+						},
+						{
+							"key": "primaryIdentifier",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "secondaryIdentifier",
+							"value": "2",
+							"type": "text"
+						},
+						{
+							"key": "excludeErroredAssets",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "dataProvider",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "excludeDuplicatedAssets",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "copyDownParentInstrumentData",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "populateExecutionVenueWithMarket",
+							"value": "false",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/task/positions",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"task",
+						"positions"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Upload Positions Without Enrichment",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "positions",
+							"type": "file",
+							"src": []
+						},
+						{
+							"key": "snapshotDate",
+							"value": "2021-11-16",
+							"type": "text"
+						},
+						{
+							"key": "format",
+							"value": "2",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/rest/api/v1/task/positions/without-enrichment",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"rest",
+						"api",
+						"v1",
+						"task",
+						"positions",
+						"without-enrichment"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Task Status",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/rest/api/v1/task/:taskID/status",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"rest",
+						"api",
+						"v1",
+						"task",
+						":taskID",
+						"status"
+					],
+					"variable": [
+						{
+							"key": "taskID",
+							"value": "c60861a2-a3b2-4599-b4ac-3b55f403dad7"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Ping",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{BaseUrl}}/ping",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"ping"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Data Provider Credentials",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"Username\": \"9008961\",\r\n    \"Password\": \"JIN0Xd3A\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/rest/api/v1/configuration/dataproviders/:providerId/credentials",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"rest",
+						"api",
+						"v1",
+						"configuration",
+						"dataproviders",
+						":providerId",
+						"credentials"
+					],
+					"variable": [
+						{
+							"key": "providerId",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Nomenclatures",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/rest/api/v1/nomenclatures",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"rest",
+						"api",
+						"v1",
+						"nomenclatures"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "basic",
+		"basic": [
+			{
+				"key": "password",
+				"value": "password",
+				"type": "string"
+			},
+			{
+				"key": "username",
+				"value": "username",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "BaseUrl",
+			"value": "https://abc1d2ef3g.execute-api.eu-west-1.amazonaws.com/prod"
+		},
+		{
+			"key": "RefinitivBaseUrl",
+			"value": "https://selectapi.datascope.refinitiv.com/"
+		},
+		{
+			"key": "RefinitivUsername",
+			"value": "*ActualRefinitivUsername*"
+		},
+		{
+			"key": "RefinitivPassword",
+			"value": "*ActualRefinitivPassword*"
+		},
+		{
+			"key": "RefinitivToken",
+			"value": ""
+		},
+		{
+			"key": "ClientEnvironment",
+			"value": "*ClientEnvironmentName*"
+		},
+		{
+			"key": "AdapptrIntegrationsBaseUrl",
+			"value": "https://abc2d2ef3g.execute-api.eu-west-1.amazonaws.com/prod"
+		}
+	]
+}

--- a/Adapptr/Sample-PostmanCollections/New_Adapptr.postman_collection
+++ b/Adapptr/Sample-PostmanCollections/New_Adapptr.postman_collection
@@ -1,0 +1,946 @@
+{
+	"info": {
+		"_postman_id": "faca8254-b3bf-4b42-864d-1bacd72f12a5",
+		"name": "Adapptr",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3279036"
+	},
+	"item": [
+		{
+			"name": "Rapptr",
+			"item": [
+				{
+					"name": "Upload Positions XML",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "password",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "username",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "positions",
+									"type": "file",
+									"src": "///FS-SF01/RDSusers$/mihristov/Desktop/test.xml"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/check",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"check"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check Rapptr Status",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "password",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "username",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/result/:id",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"result",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "6fc60e00-d6d8-4460-919b-ae3000c0dea9"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get JWT",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*.fundapps.co/jwtbearer/token",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"jwtbearer",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "XSD",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://*ClientEnvironment*-api.fundapps.co/v1/expost/xsd",
+							"protocol": "https",
+							"host": [
+								"*ClientEnvironment*-api",
+								"fundapps",
+								"co"
+							],
+							"path": [
+								"v1",
+								"expost",
+								"xsd"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Refinitiv",
+			"item": [
+				{
+					"name": "GetAssetCategories",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Search/GetAssetCategories",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Search",
+								"GetAssetCategories"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesShareholderDisclosure",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"CUSIP\",\r\n            \"Par Value\",\r\n            \"Nominal Value\",\r\n            \"Nominal Value Currency\",\r\n            \"Total Issued Share Capital - Currency\",\r\n            \"Asset Type\",\r\n            \"ISIN\",\r\n            \"Market MIC\",\r\n            \"Security Long Name\",\r\n            \"Issuer Name\",\r\n            \"Currency Code\",\r\n            \"Close Price\",\r\n            \"Issuer PermID\",\r\n            \"MIC List\",\r\n            \"Notional Amount\",\r\n            \"Lot Size\",\r\n            \"Strike Price\",\r\n            \"Total Amount Outstanding\",\r\n            \"Conversion Ratio\",\r\n            \"Delta\",\r\n            \"Ticker\",\r\n            \"Shares Amount\",\r\n            \"Round Lot Size\",\r\n            \"Voting Rights Per Share\",\r\n            \"Country of Incorporation\",\r\n            \"Market Capitalization\",\r\n            \"Total Shares - Treasury\",\r\n            \"Total Shares - Outstanding\",\r\n            \"Total Voting Rights - Default\",\r\n            \"Total Voting Shares - Default\",\r\n            \"Maturity Date\",\r\n            \"Country of Issuance\",\r\n            \"SEC Section 12\",\r\n            \"Security Description\",\r\n            \"Entity LEI\",\r\n            \"Share Class\",\r\n            \"Bond Future Modified Duration\",\r\n            \"Debt Outstanding - Total Amount Outstanding\",\r\n            \"Convertible Redemption Type\",\r\n            \"GICS Industry Code\",\r\n            \"Expiration Date\",\r\n            \"Underlying RIC\",\r\n            \"Covered Bond Flag\",\r\n            \"Asset Ratio Against\",\r\n            \"Asset Ratio For\",\r\n            \"Convertible Effective Date\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Convertible Flag\",\r\n            \"Convertible Sub Type Code\",\r\n            \"When Issued Flag\",\r\n            \"Conversion Fixed Shares\",\r\n            \"Method of Delivery\",\r\n            \"Exercise Style\",\r\n            \"Put Call Flag\",\r\n            \"Exchange Listed Flag\",\r\n            \"Exchange Code\",\r\n            \"Industry Description\",\r\n            \"Industry Sector Code\",\r\n            \"Industry Sector Description\",\r\n            \"Industry Sub-Description\",\r\n            \"Industry Sub-Sector Code\",\r\n            \"Industry Sub-Sector Description\",\r\n            \"Parent Immediate Industry Sector\",\r\n            \"Parent Immediate Industry Description\",\r\n            \"Industry Classification Benchmark Code\",\r\n            \"Industry Classification Benchmark Description\",\r\n            \"Parent Industry Description\",\r\n            \"Asset Status Description\",\r\n            \"Underlying ISIN\",\r\n            \"Total Issued Share Capital\",\r\n            \"Domicile\",\r\n            \"Executable Ratio Shares Held\",\r\n            \"Executable Ratio Resulting Shares\",\r\n            \"Total Voting Rights - Treasury\",\r\n            \"Security Long Description\",\r\n            \"Total Voting Shares - Treasury\",\r\n            \"GICS Industry Description Code\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n  {\r\n    \"Identifier\": \"KYG9830T1067\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"ES0113900J37\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"CH0108503795\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"TSLA.OQ\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"BSANTANDER.SN\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"BE0974288202\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"IT0000336518\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"PIN.UNL\",\r\n    \"IdentifierType\": \"Ric\"\r\n  },\r\n  {\r\n    \"Identifier\": \"FR0000031122\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"GB00B019KW72\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"GB00B03MLX29\",\r\n    \"IdentifierType\": \"Isin\"\r\n  },\r\n  {\r\n    \"Identifier\": \"US0378331005\",\r\n    \"IdentifierType\": \"Isin\"\r\n  }\r\n],\r\n            \"ValidationOptions\":{\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesCombined",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"CUSIP\",\r\n            \"Par Value\",\r\n            \"Nominal Value\",\r\n            \"Nominal Value Currency\",\r\n            \"Total Issued Share Capital - Currency\",\r\n            \"Asset Type\",\r\n            \"ISIN\",\r\n            \"Market MIC\",\r\n            \"Security Long Name\",\r\n            \"Issuer Name\",\r\n            \"Currency Code\",\r\n            \"Close Price\",\r\n            \"Issuer PermID\",\r\n            \"MIC List\",\r\n            \"Notional Amount\",\r\n            \"Lot Size\",\r\n            \"Strike Price\",\r\n            \"Total Amount Outstanding\",\r\n            \"Conversion Ratio\",\r\n            \"Delta\",\r\n            \"Ticker\",\r\n            \"Shares Amount\",\r\n            \"Round Lot Size\",\r\n            \"Voting Rights Per Share\",\r\n            \"Country of Incorporation\",\r\n            \"Market Capitalization\",\r\n            \"Total Shares - Treasury\",\r\n            \"Total Shares - Outstanding\",\r\n            \"Total Voting Rights - Default\",\r\n            \"Total Voting Shares - Default\",\r\n            \"Maturity Date\",\r\n            \"Country of Issuance\",\r\n            \"SEC Section 12\",\r\n            \"Security Description\",\r\n            \"Entity LEI\",\r\n            \"Share Class\",\r\n            \"Bond Future Modified Duration\",\r\n            \"Debt Outstanding - Total Amount Outstanding\",\r\n            \"Convertible Redemption Type\",\r\n            \"GICS Industry Code\",\r\n            \"Expiration Date\",\r\n            \"Underlying RIC\",\r\n            \"Covered Bond Flag\",\r\n            \"Asset Ratio Against\",\r\n            \"Asset Ratio For\",\r\n            \"Convertible Effective Date\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Convertible Flag\",\r\n            \"Convertible Sub Type Code\",\r\n            \"When Issued Flag\",\r\n            \"Conversion Fixed Shares\",\r\n            \"Method of Delivery\",\r\n            \"Exercise Style\",\r\n            \"Put Call Flag\",\r\n            \"Exchange Listed Flag\",\r\n            \"Exchange Code\",\r\n            \"Industry Description\",\r\n            \"Industry Sector Code\",\r\n            \"Industry Sector Description\",\r\n            \"Industry Sub-Description\",\r\n            \"Industry Sub-Sector Code\",\r\n            \"Industry Sub-Sector Description\",\r\n            \"Parent Immediate Industry Sector\",\r\n            \"Parent Immediate Industry Description\",\r\n            \"Industry Classification Benchmark Code\",\r\n            \"Industry Classification Benchmark Description\",\r\n            \"Parent Industry Description\",\r\n            \"Asset Status Description\",\r\n            \"Underlying ISIN\",\r\n            \"Total Issued Share Capital\",\r\n            \"Domicile\",\r\n            \"Executable Ratio Shares Held\",\r\n            \"Executable Ratio Resulting Shares\",\r\n            \"Total Voting Rights - Treasury\",\r\n            \"Last Updated Open Interest\",\r\n            \"Security Long Description\",\r\n            \"Share Delivery Code\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n                {\r\n                    \"Identifier\": \"US98421U1088\",\r\n                    \"IdentifierType\": \"Isin\"\r\n                }\r\n            ],\r\n            \"ValidationOptions\": {\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExtractWithNotesPositionLimits",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"ExtractionRequest\": {\r\n        \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.CompositeExtractionRequest\",\r\n        \"ContentFieldNames\": [\r\n            \"Asset Type\",\r\n            \"Asset SubType\",\r\n            \"Refinitiv Classification Scheme\",\r\n            \"Underlying RIC\",\r\n            \"Underlying ISIN\",\r\n            \"Currency Code\",\r\n            \"Security Description\",\r\n            \"Close Price\",\r\n            \"Market MIC\",\r\n            \"Exchange Code\",\r\n            \"Asset Status Description\",\r\n            \"Ticker\",\r\n            \"Lot Size\",\r\n            \"Expiration Date\",\r\n            \"Delta\",\r\n            \"Method of Delivery\",\r\n            \"Last Updated Open Interest\",\r\n            \"Put Call Flag\",\r\n            \"Security Long Description\"\r\n        ],\r\n        \"IdentifierList\": {\r\n            \"@odata.type\": \"#DataScope.Select.Api.Extractions.ExtractionRequests.InstrumentIdentifierList\",\r\n            \"InstrumentIdentifiers\": [\r\n                {\r\n                    \"Identifier\": \"BYW4289\",\r\n                    \"IdentifierType\": \"Sedol\"\r\n                },\r\n                {\r\n                    \"Identifier\": \"BN2BD13\",\r\n                    \"IdentifierType\": \"Sedol\"\r\n                }\r\n            ],\r\n            \"ValidationOptions\":{\r\n                \"UseExchangeCodeInsteadOfLipper\": true,\r\n                \"AllowUnsupportedInstruments\": true\r\n            },\r\n            \"UseUserPreferencesForValidationOptions\": false\r\n        }\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Extractions/ExtractWithNotes",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Extractions",
+								"ExtractWithNotes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Request Token",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"Credentials\": {\r\n        \"Username\": \"9008961\",\r\n        \"Password\": \"JIN0Xd3A\"\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Authentication/RequestToken",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Authentication",
+								"RequestToken"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetGicsIndustryClassifications",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{RefinitivBaseUrl}}/RestApi/v1/Search/GetGicsIndustryClassifications ",
+							"host": [
+								"{{RefinitivBaseUrl}}"
+							],
+							"path": [
+								"RestApi",
+								"v1",
+								"Search",
+								"GetGicsIndustryClassifications "
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "oauth2",
+				"oauth2": [
+					{
+						"key": "headerPrefix",
+						"value": "Token",
+						"type": "string"
+					},
+					{
+						"key": "addTokenTo",
+						"value": "header",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"pm.sendRequest({",
+							"    url: pm.variables.get(\"RefinitivBaseUrl\") + '/RestApi/v1/Authentication/RequestToken',",
+							"    method: 'POST',",
+							"    header: {",
+							"        'content-type': 'application/json'",
+							"    },",
+							"    body: {",
+							"        mode: 'raw',",
+							"        raw: JSON.stringify({",
+							"          \"Credentials\": {",
+							"            \"Username\": pm.variables.get(\"RefinitivUsername\"),",
+							"            \"Password\": pm.variables.get(\"RefinitivPassword\")",
+							"          }",
+							"        })",
+							"    }",
+							"}, function (err, res) {",
+							"    pm.variables.set(\"RefinitivToken\", res.json().value);",
+							"});"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Adapptr Integrations",
+			"item": [
+				{
+					"name": "Convert - Large",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "storageFileName",
+									"value": "2d808d79fc31442b8f2f0a914d209558-hassana format.xls",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/large/convert",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"large",
+								"convert"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Ping",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/ping",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"ping"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Pre Signed Url",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/large/pre-signed-url?fileName=Hassana Format.XLS",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"large",
+								"pre-signed-url"
+							],
+							"query": [
+								{
+									"key": "fileName",
+									"value": "Hassana Format.XLS"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Upload File Using PreSignedUrl",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": "///FS-SF01/RDSusers$/mihristov/Downloads/adapptr-data/Hassana Format.XLS"
+							}
+						},
+						"url": {
+							"raw": "https://adapptr-integrations-localhost.s3-eu-west-1.amazonaws.com/client-files/2d808d79fc31442b8f2f0a914d209558-hassana%20format.xls?X-Amz-Expires=1800&X-Amz-Security-Token=IQoJb3JpZ2luX2VjELH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJIMEYCIQCHN%2FCbnr8qQ1avIC6TbuCo4mx0FP1fho%2BLFDgiQTe0zQIhAK%2Ftwn5oUbfM6NqTgutkAnPpqcjYKPJ581OQzMtOjOhSKqEDCLr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQARoMNjg0Njc4Njk4NDQzIgymg%2Fmgr0SkQGs00Vkq9QIlIKCJsPvMGfA2bbEq1SRERF34BEx4CxKS0PQfC8APqRtS%2BitkIJzgdDzWR61sul5wVP7CtjHFCUPNRtyWcoFI8klViAe3SsCSQ0n9QBfMSfWUlM%2F797FljzwijWRQ8xml8EumOkckh%2BWUNbCFii0LchAjQUAulZyUlPrbTmUpLUV50Fo%2BNXtrGXqR743nSsoJApFlneOSTfx3AN5XPYNk8nswVsGD1OSuzmSiljmKith1aYW4LHE85jZitDCemPabv6IQe6lSJpVK2A9aTNWnT7pIN25wuyMWRBDPpHXwv8Lex5zqdbqQ%2BzpzTgODxkXr2GDkQCyqDwxk%2BZctqM%2BddTKhPYydVtIkgUDqGj%2BsiARW2JXUAeZuj6oSMYjDsvTPEX4e%2FQcsuH7LB8n8fo4XW%2Bv3MJ6Ytl8EtYLiXxNdLyOxm9blJleWU%2BzP6D%2BtMoQK6gBygzkKmJfo6ONnDW53f2SNCo7F7V6z3YyTgxXOBGx1%2FO07MIT8344GOqUBSWI7oficGtv3i9L%2BvlLW9G7uwqbyYCuKqrcHUGWGCWibK5zcMp6byaheabyDqwRs%2BOXT7NzgqvGDQFkIRg4gT0XptclV9hFclXT5nyoR3nV8wVslLi1Nh6NQ8GZfNkzunAG%2F11HdSlHsPC%2FJO13Q0dC4ak12d45Yk7Ci4RdysarVZz42TkrgpzuvLGwA%2BLjz4qsPlncFptq9Ngb5I7HNHDlFZ3F%2B&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAZ62QH2XFZFLGTJXY/20220107/eu-west-1/s3/aws4_request&X-Amz-Date=20220107T084956Z&X-Amz-SignedHeaders=host&X-Amz-Signature=eed68d46adc1a55d36c7d1cfcef689c73b1094506f176d4136d7451e84d21287",
+							"protocol": "https",
+							"host": [
+								"adapptr-integrations-localhost",
+								"s3-eu-west-1",
+								"amazonaws",
+								"com"
+							],
+							"path": [
+								"client-files",
+								"2d808d79fc31442b8f2f0a914d209558-hassana%20format.xls"
+							],
+							"query": [
+								{
+									"key": "X-Amz-Expires",
+									"value": "1800"
+								},
+								{
+									"key": "X-Amz-Security-Token",
+									"value": "IQoJb3JpZ2luX2VjELH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMSJIMEYCIQCHN%2FCbnr8qQ1avIC6TbuCo4mx0FP1fho%2BLFDgiQTe0zQIhAK%2Ftwn5oUbfM6NqTgutkAnPpqcjYKPJ581OQzMtOjOhSKqEDCLr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQARoMNjg0Njc4Njk4NDQzIgymg%2Fmgr0SkQGs00Vkq9QIlIKCJsPvMGfA2bbEq1SRERF34BEx4CxKS0PQfC8APqRtS%2BitkIJzgdDzWR61sul5wVP7CtjHFCUPNRtyWcoFI8klViAe3SsCSQ0n9QBfMSfWUlM%2F797FljzwijWRQ8xml8EumOkckh%2BWUNbCFii0LchAjQUAulZyUlPrbTmUpLUV50Fo%2BNXtrGXqR743nSsoJApFlneOSTfx3AN5XPYNk8nswVsGD1OSuzmSiljmKith1aYW4LHE85jZitDCemPabv6IQe6lSJpVK2A9aTNWnT7pIN25wuyMWRBDPpHXwv8Lex5zqdbqQ%2BzpzTgODxkXr2GDkQCyqDwxk%2BZctqM%2BddTKhPYydVtIkgUDqGj%2BsiARW2JXUAeZuj6oSMYjDsvTPEX4e%2FQcsuH7LB8n8fo4XW%2Bv3MJ6Ytl8EtYLiXxNdLyOxm9blJleWU%2BzP6D%2BtMoQK6gBygzkKmJfo6ONnDW53f2SNCo7F7V6z3YyTgxXOBGx1%2FO07MIT8344GOqUBSWI7oficGtv3i9L%2BvlLW9G7uwqbyYCuKqrcHUGWGCWibK5zcMp6byaheabyDqwRs%2BOXT7NzgqvGDQFkIRg4gT0XptclV9hFclXT5nyoR3nV8wVslLi1Nh6NQ8GZfNkzunAG%2F11HdSlHsPC%2FJO13Q0dC4ak12d45Yk7Ci4RdysarVZz42TkrgpzuvLGwA%2BLjz4qsPlncFptq9Ngb5I7HNHDlFZ3F%2B"
+								},
+								{
+									"key": "X-Amz-Algorithm",
+									"value": "AWS4-HMAC-SHA256"
+								},
+								{
+									"key": "X-Amz-Credential",
+									"value": "ASIAZ62QH2XFZFLGTJXY/20220107/eu-west-1/s3/aws4_request"
+								},
+								{
+									"key": "X-Amz-Date",
+									"value": "20220107T084956Z"
+								},
+								{
+									"key": "X-Amz-SignedHeaders",
+									"value": "host"
+								},
+								{
+									"key": "X-Amz-Signature",
+									"value": "eed68d46adc1a55d36c7d1cfcef689c73b1094506f176d4136d7451e84d21287"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Convert",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "positions",
+									"type": "file",
+									"src": "///FS-SF01/RDSusers$/mihristov/Downloads/adapptr-data/Hassana Format.XLS"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{AdapptrIntegrationsBaseUrl}}/rest/api/v1/positions/convert",
+							"host": [
+								"{{AdapptrIntegrationsBaseUrl}}"
+							],
+							"path": [
+								"rest",
+								"api",
+								"v1",
+								"positions",
+								"convert"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "basic",
+				"basic": [
+					{
+						"key": "password",
+						"value": "password",
+						"type": "string"
+					},
+					{
+						"key": "username",
+						"value": "username",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Upload Positions",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "positions",
+							"type": "file",
+							"src": "///FS-SF01/RDSusers$/mihristov/Desktop/Case 3.csv"
+						},
+						{
+							"key": "snapshotDate",
+							"value": "2022-03-30",
+							"type": "text"
+						},
+						{
+							"key": "services",
+							"value": "2",
+							"type": "text"
+						},
+						{
+							"key": "primaryIdentifier",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "secondaryIdentifier",
+							"value": "2",
+							"type": "text"
+						},
+						{
+							"key": "excludeErroredAssets",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "dataProvider",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "excludeDuplicatedAssets",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "copyDownParentInstrumentData",
+							"value": "false",
+							"type": "text"
+						},
+						{
+							"key": "populateExecutionVenueWithMarket",
+							"value": "false",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/task/positions",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"task",
+						"positions"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Upload Positions Without Enrichment",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "positions",
+							"type": "file",
+							"src": []
+						},
+						{
+							"key": "snapshotDate",
+							"value": "2021-11-16",
+							"type": "text"
+						},
+						{
+							"key": "format",
+							"value": "2",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/task/positions/without-enrichment",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"task",
+						"positions",
+						"without-enrichment"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Task Status",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/task/:taskID/status",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"task",
+						":taskID",
+						"status"
+					],
+					"variable": [
+						{
+							"key": "taskID",
+							"value": "c60861a2-a3b2-4599-b4ac-3b55f403dad7"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Ping",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/ping",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"ping"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Data Provider Credentials",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"Username\": \"9008961\",\r\n    \"Password\": \"JIN0Xd3A\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/configuration/dataproviders/:providerId/credentials",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"configuration",
+						"dataproviders",
+						":providerId",
+						"credentials"
+					],
+					"variable": [
+						{
+							"key": "providerId",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Nomenclatures",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Client-Environment",
+						"value": "{{ClientEnvironment}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{BaseUrl}}/api/adapptr/v1/nomenclatures",
+					"host": [
+						"{{BaseUrl}}"
+					],
+					"path": [
+						"api",
+						"adapptr",
+						"v1",
+						"nomenclatures"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "basic",
+		"basic": [
+			{
+				"key": "password",
+				"value": "password",
+				"type": "string"
+			},
+			{
+				"key": "username",
+				"value": "username",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "BaseUrl",
+			"value": "http://*ClientEnvironment*-svc.fundapps.co"
+		},
+		{
+			"key": "RefinitivBaseUrl",
+			"value": "https://selectapi.datascope.refinitiv.com/"
+		},
+		{
+			"key": "RefinitivUsername",
+			"value": "*ActualRefinitivUsername*"
+		},
+		{
+			"key": "RefinitivPassword",
+			"value": "*ActualRefinitivPassword*"
+		},
+		{
+			"key": "RefinitivToken",
+			"value": ""
+		},
+		{
+			"key": "ClientEnvironment",
+			"value": "*ClientEnvironmentName*"
+		},
+		{
+			"key": "AdapptrIntegrationsBaseUrl",
+			"value": "http://*ClientEnvironment*-svc.fundapps.co"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Our API methods return machine readable responses in XML format, including error
 
 ## Base URI
 
-If your Rapptr installation is available at https://%company%.fundapps.co/ the URI from which your API is available is https://%company%-api.fundapps.co/. Ditto, staging api is available at https://%company%-staging-api.fundapps.co/
+If your Rapptr installation is available at <https://%company%.fundapps.co/> the URI from which your API is available is <https://%company%-api.fundapps.co/>. Ditto, staging api is available at <https://%company%-staging-api.fundapps.co/>
 All requests made to our API must be over HTTPS.
 
 ## Authentication
@@ -231,9 +231,17 @@ The RIAN API is Position Limits (PL) enabled, please make sure to select "PL" fr
 
 # FundApps Adapptr Spec & Examples
 
-We provide a REST-ful HTTPS API for automated interfaces between your systems and our Adapptr service. Our API uses predictable, resource-oriented URI's to make methods available and HTTP response codes to indicate errors. These built-in HTTP features, like HTTP authentication and HTTP verbs are part of the standards underpinning the modern web and are able to be understood by off-the-shelf HTTP clients.
+We provide a RESTful HTTPS API for automated interfaces between your systems and our Adapptr service. Our API uses predictable, resource-oriented URIs to make methods available and HTTP response codes to indicate errors. These built-in HTTP features, like HTTP authentication and HTTP verbs are part of the standards underpinning the modern web and are able to be understood by off-the-shelf HTTP clients.
 
 Our API methods return machine readable responses in JSON format, including error conditions.
+
+Please note our collection of Adapptr samples:
+
+- [Sample Code and Scripts](Adapptr/Sample-Code&Scripts)
+- [Sample Import Files](Adapptr/Sample-ImportFiles)
+- [Sample Postman Collections](Adapptr/Sample-PostmanCollections)
+
+See [here](Adapptr/APIMigration.md) for a page detailing the Adapptr API migration.
 
 ## Base URI
 
@@ -298,7 +306,6 @@ The `primaryIdentifier` _[optional]_ parameter can be included if you need to sp
 
 The `secondaryIdentifier` _[optional]_ parameter can be included if you need to specify which identifier to fall back to if your primaryIdentifier is not populated. For example if your primaryIdentifier is set to 1 for ISIN and you have a position which doesn't have an ISIN but has a SEDOL, setting the secondaryIdentifier to 2 (SEDOL) would tell Adapptr to use SEDOL to query data from your market data provider if ISIN is not populated. By default this is empty. The value could be obtained from the [Available Nomenclatures](#available-nomenclatures-get-restapiv1nomenclatures) endpoint.
 
-
 The `excludeErroredAssets` _[optional]_ is a boolean parameter that can be set if you need to send the positions to Rapptr despite errors due to incomplete data from your market data provider. Default value: `false`
 
 The `dataProvider` _[optional]_ is an integer parameter that can be set if you need to select a specific data provider. Default value is `1` (Refinitiv). A list of all supported providers can be obtained from the [Available Nomenclatures](#available-nomenclatures-get-restapiv1nomenclatures) endpoint.
@@ -331,7 +338,7 @@ This method works only with the FundApps Position Limits service. Please see [he
     "status": {
         "id": 1,
         "name": "Accepted",
-	"description": "Position file accepted. Please check the tracking endpoint to check for any errors in the file upload and to track the progress of the file enrichment and transmission to Rapptr."
+ "description": "Position file accepted. Please check the tracking endpoint to check for any errors in the file upload and to track the progress of the file enrichment and transmission to Rapptr."
     },
     "dateCreated": "2021-06-17T09:20:58.9553866Z",
     "dateUpdated": null,
@@ -375,7 +382,7 @@ Once transmitted, the request will give the Rapptr trackingEndpoint url which ca
     "dateUpdated": "2021-07-22T17:13:19.024+03:00",
     "trackingEndpoint": "https://demo-melon-api.fundapps.co/v1/expost/result/38ba5713-c253-42d1-896a-bd6e00ea5ec3",
     "statusReport": {
-	"errors": null,
+ "errors": null,
         "warnings": [
             "Identifier: <Identifier> | Component is required for this instrument. Refinitiv returned null or empty value for UnderlyingISIN and UnderlyingRIC. Consider providing ComponentISIN value in the positions file.",
             "Identifier: <Identifier> | Empty result while getting enrichment data for item. Please check if the identifier is valid.",

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For all methods, the header `X-Client-Environment` is required. This must be pop
 
 For all methods, authentication is made against your FundApps environment. You are required to include the Username and Password of an API user in the FundApps environment you have set in the `X-Client-Environment` header.
 
-## Available Nomenclatures `GET /rest/api/v1/nomenclatures`
+## Available Nomenclatures `GET /api/adapptr/v1/nomenclatures`
 
 List of available data providers, identifier types, position services and more. Those can be requested from this endpoint. You must then use the appropriate ids for parameters in other requests.
 
@@ -275,7 +275,7 @@ List of available data providers, identifier types, position services and more. 
 | 1   | FundApps         |
 | 2   | Consensys       |
 
-## Data Provider Credentials `POST /rest/api/v1/configuration/dataproviders/:providerId/credentials`
+## Data Provider Credentials `POST /api/adapptr/v1/configuration/dataproviders/:providerId/credentials`
 
 If you are using Refinitiv data you must submit your username and password to this endpoint. Before being able to post a file to Adapptr, your data provider credentials must be set. Your file upload will otherwise fail because FundApps will be unable to connect and authenticate against the data provider.
 
@@ -284,7 +284,7 @@ If you are using Refinitiv data you must submit your username and password to th
 e.g
 `{ "Username": "[Username]", "Password": "[Password]" }`
 
-## `POST /rest/api/v1/task/positions`
+## `POST /api/adapptr/v1/task/positions`
 
 Upload daily positions. This method expects a csv format ([example Adapptr position files](Adapptr/)). The response includes a taskId and a trackingEndpoint that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.
 
@@ -307,7 +307,7 @@ The `copyDownParentInstrumentData` _[optional]_ is a boolean parameter that can 
 
 The `populateExecutionVenueWithMarket` _[optional]_ is a boolean parameter that can be set if you need to use your data provider's Market field to populate ExecutionVenue of your assets. Default value: `false`
 
-## `POST /rest/api/v1/task/positions/without-enrichment`
+## `POST /api/adapptr/v1/task/positions/without-enrichment`
 
 This method converts the Consensys or Adapptr csv file format into the FundApps required format for the Position Limits service only. The response includes a taskId and a trackingEndpoint that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.
 
@@ -335,11 +335,11 @@ This method works only with the FundApps Position Limits service. Please see [he
     },
     "dateCreated": "2021-06-17T09:20:58.9553866Z",
     "dateUpdated": null,
-    "trackingEndpoint": "/prod/rest/api/v1/task/35ce6225-1534-4e7e-8199-611a8647f8ee/status"
+    "trackingEndpoint": "/prod/api/adapptr/v1/task/35ce6225-1534-4e7e-8199-611a8647f8ee/status"
 }
 ```
 
-## `GET /rest/api/v1/task/:taskID/status`
+## `GET /api/adapptr/v1/task/:taskID/status`
 
 GET the task status. This method returns a status of the requested TaskId and if the task has failed, the errors that have contributed to the failure.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Our API methods return machine readable responses in XML format, including error
 
 ## Base URI
 
-If your Rapptr installation is available at <https://%company%.fundapps.co/> the URI from which your API is available is <https://%company%-api.fundapps.co/>. Ditto, staging api is available at <https://%company%-staging-api.fundapps.co/>
+If your Rapptr installation is available at <https://%company%.fundapps.co/>, your API URI is available at <https://%company%-api.fundapps.co/>. Same rule applies for your staging API, available at <https://%company%-staging-api.fundapps.co/>.  
 All requests made to our API must be over HTTPS.
 
 ## Authentication
@@ -241,7 +241,7 @@ Please note our collection of Adapptr samples:
 - [Sample Import Files](Adapptr/Sample-ImportFiles)
 - [Sample Postman Collections](Adapptr/Sample-PostmanCollections)
 
-See [here](Adapptr/APIMigration.md) for a page detailing the Adapptr API migration.
+ℹ See [here](Adapptr/APIMigration.md) for a page detailing the Adapptr API migration.
 
 ## Base URI
 
@@ -258,7 +258,7 @@ For all methods, the header `X-Client-Environment` is required. This must be pop
 
 For all methods, authentication is made against your FundApps environment. You are required to include the Username and Password of an API user in the FundApps environment you have set in the `X-Client-Environment` header.
 
-## Available Nomenclatures `GET /api/adapptr/v1/nomenclatures`
+## Available Nomenclatures `GET /rest/api/v1/nomenclatures` (migrated: `GET /api/adapptr/v1/nomenclatures`)
 
 List of available data providers, identifier types, position services and more. Those can be requested from this endpoint. You must then use the appropriate ids for parameters in other requests.
 
@@ -283,7 +283,7 @@ List of available data providers, identifier types, position services and more. 
 | 1   | FundApps         |
 | 2   | Consensys       |
 
-## Data Provider Credentials `POST /api/adapptr/v1/configuration/dataproviders/:providerId/credentials`
+## Data Provider Credentials `POST /rest/api/v1/configuration/dataproviders/:providerId/credentials` (migrated `POST /api/adapptr/v1/configuration/dataproviders/:providerId/credentials`)
 
 If you are using Refinitiv data you must submit your username and password to this endpoint. Before being able to post a file to Adapptr, your data provider credentials must be set. Your file upload will otherwise fail because FundApps will be unable to connect and authenticate against the data provider.
 
@@ -292,11 +292,11 @@ If you are using Refinitiv data you must submit your username and password to th
 e.g
 `{ "Username": "[Username]", "Password": "[Password]" }`
 
-## `POST /api/adapptr/v1/task/positions`
+## Upload positions `POST /rest/api/v1/task/positions` (migrated: `POST /api/adapptr/v1/task/positions`)
 
-Upload daily positions. This method expects a csv format ([example Adapptr position files](Adapptr/)). The response includes a taskId and a trackingEndpoint that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.
+Upload daily positions. This method expects a csv format ([example Adapptr position files](Adapptr/)). The response includes a `taskId` and a `trackingEndpoint` that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.  
 
-The `positions` parameter must be the file that you need to upload.
+The `positions` parameter must be the file that you need to upload.  
 
 The `snapshotDate` parameter must be included as a parameter in the format `yyyy-mm-dd`. This is the snapshot date of the positions being uploaded in the csv file.
 
@@ -314,13 +314,13 @@ The `copyDownParentInstrumentData` _[optional]_ is a boolean parameter that can 
 
 The `populateExecutionVenueWithMarket` _[optional]_ is a boolean parameter that can be set if you need to use your data provider's Market field to populate ExecutionVenue of your assets. Default value: `false`
 
-## `POST /api/adapptr/v1/task/positions/without-enrichment`
+## Upload positions without enrichment `POST /rest/api/v1/task/positions/without-enrichment` (migrated: `POST /api/adapptr/v1/task/positions/without-enrichment`)
 
-This method converts the Consensys or Adapptr csv file format into the FundApps required format for the Position Limits service only. The response includes a taskId and a trackingEndpoint that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.
+This method converts the Consensys or Adapptr csv file format into the FundApps required format for the Position Limits service only. The response includes a taskId and a trackingEndpoint that can then be polled via the GET method to monitor the progress of the task through the Adapptr service.  
 
-The `positions` parameter must be the file that you need to upload.
+The `positions` parameter must be the file that you need to upload.  
 
-The `snapshotDate` parameter must be included as a parameter in the format `yyyy-mm-dd`. This is the snapshot date of the positions being uploaded in the csv file.
+The `snapshotDate` parameter must be included as a parameter in the format `yyyy-mm-dd`. This is the snapshot date of the positions being uploaded in the CSV file.
 
 The `format` _[optional]_ _[default value = 2]_ parameter can be included if you prefer using different file data format. A list of all supported file data formats can be obtained from the [Available Nomenclatures](#available-nomenclatures-get-restapiv1nomenclatures) endpoint.
 
@@ -338,7 +338,7 @@ This method works only with the FundApps Position Limits service. Please see [he
     "status": {
         "id": 1,
         "name": "Accepted",
- "description": "Position file accepted. Please check the tracking endpoint to check for any errors in the file upload and to track the progress of the file enrichment and transmission to Rapptr."
+        "description": "Position file accepted. Please check the tracking endpoint to check for any errors in the file upload and to track the progress of the file enrichment and transmission to Rapptr."
     },
     "dateCreated": "2021-06-17T09:20:58.9553866Z",
     "dateUpdated": null,
@@ -346,7 +346,7 @@ This method works only with the FundApps Position Limits service. Please see [he
 }
 ```
 
-## `GET /api/adapptr/v1/task/:taskID/status`
+## Task status `GET /rest/api/v1/task/:taskID/status` (migrated: `GET /api/adapptr/v1/task/:taskID/status`)
 
 GET the task status. This method returns a status of the requested TaskId and if the task has failed, the errors that have contributed to the failure.
 
@@ -362,7 +362,7 @@ There are 4 status ids
 | 6   | Waiting Extractions        | A request is sent to the data provider, but there is no response yet.                                                                                                             |
 | 500 | Failed                    | Job has failed. Please read errors to identify cause of job failure.                                                                                                              |
 
-Once transmitted, the request will give the Rapptr trackingEndpoint url which can be polled to see the status of the xml positions file upload to FundApps.
+Once transmitted, the request will give the Rapptr `trackingEndpoint` url which can be polled to check the status of the XML positions file upload to FundApps.
 
 #### Sample Response
 
@@ -382,7 +382,7 @@ Once transmitted, the request will give the Rapptr trackingEndpoint url which ca
     "dateUpdated": "2021-07-22T17:13:19.024+03:00",
     "trackingEndpoint": "https://demo-melon-api.fundapps.co/v1/expost/result/38ba5713-c253-42d1-896a-bd6e00ea5ec3",
     "statusReport": {
- "errors": null,
+        "errors": null,
         "warnings": [
             "Identifier: <Identifier> | Component is required for this instrument. Refinitiv returned null or empty value for UnderlyingISIN and UnderlyingRIC. Consider providing ComponentISIN value in the positions file.",
             "Identifier: <Identifier> | Empty result while getting enrichment data for item. Please check if the identifier is valid.",


### PR DESCRIPTION
The docs are being updated under the assumption that we will be providing each client with their cloudfront distribution alternate domain as Base Url / `APIUri`, e.g. `demo-melon-svc.fundapps.co` for `demo-melon`