### PR TITLE
Add check for dotsourcing scripts instead of just running them

### DIFF
--- a/Adapptr/Sample-Code&Scripts/Powershell/check-task-status.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/check-task-status.ps1
@@ -4,6 +4,15 @@
 #Get-Status -User "[USERNAME]" -Password "[PASSWORD]" -TaskId "[TASKID]"  -ClientEnvironment "[ALIAS]"
 # For how to encrypt passwords on a machine before using as a parameter see here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertto-securestring?view=powershell-7
 
+$isDotSourced = $MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq ''
+
+if (-not $isDotSourced)
+{
+    Write-Host "You need to source this script, please run using '. .\check-task-status.ps1'. The 'dot space' has been omitted."
+    Break 1
+}
+
+
 Write-Host "Install functions"
 
 function API-GET {

--- a/Adapptr/Sample-Code&Scripts/Powershell/entry-provider-credentials.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/entry-provider-credentials.ps1
@@ -1,3 +1,10 @@
+if (-Not (Test-Path ".\post-data-provider-credentials.ps1"))
+{
+    Write-Host "Please download the required helper functions from 'https://github.com/fundapps/TechDocs/blob/main/Adapptr/Sample-Code%26Scripts/Powershell/post-data-provider-credentials.ps1' into a file called 'post-data-provider-credentials.ps1'."
+    Write-Host "If you have this file locally, you might need to run this script from the folder containing this script."
+    Break 1
+}
+
 . ".\post-data-provider-credentials.ps1"
 
 $adapptr_username = Read-Host "Adapptr username"

--- a/Adapptr/Sample-Code&Scripts/Powershell/post-data-provider-credentials.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/post-data-provider-credentials.ps1
@@ -6,6 +6,14 @@
 # If you need to use Bloomberg as a data provider the implementation given below is not applicable
 # Please refer to the documentation for more info: https://github.com/fundapps/api-examples#data-provider-credentials-post-restapiv1configurationdataprovidersprovideridcredentials
 
+$isDotSourced = $MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq ''
+
+if (-not $isDotSourced)
+{
+    Write-Host "You need to source this script, please run using '. .\post-data-provider-credentials.ps1'. The 'dot space' has been omitted."
+    Break 1
+}
+
 Write-Host "Install functions"
 
 function API-Post-Json {

--- a/Adapptr/Sample-Code&Scripts/Powershell/upload-positions-without-enrichment.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/upload-positions-without-enrichment.ps1
@@ -1,7 +1,15 @@
 #
-# Usage: First run the script, then call the function below. You might need to run the script with . .\upload-positions.ps1 instead of .\upload-positions.ps1
+# Usage: First run the script, then call the function below. You might need to run the script with . .\upload-positions-without-enrichment.ps1 instead of .\upload-positions-without-enrichment.ps1
 # Import-Positions -User "[USERNAME]" -Password "[PASSWORD]" -File "[PATH_TO_FILE]" -ClientEnvironment "[ALIAS]"
 # For how to encrypt passwords on a machine before using as a parameter see here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertto-securestring?view=powershell-7
+
+$isDotSourced = $MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq ''
+
+if (-not $isDotSourced)
+{
+    Write-Host "You need to source this script, please run using '. .\upload-positions-without-enrichment.ps1'. The 'dot space' has been omitted."
+    Break 1
+}
 
 Write-Host "Install functions"
 

--- a/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
+++ b/Adapptr/Sample-Code&Scripts/Powershell/upload-positions.ps1
@@ -4,6 +4,14 @@
 # Import-Positions -User "[USERNAME]" -Password "[PASSWORD]" -File "[PATH_TO_FILE]" -ClientEnvironment "[ALIAS]"
 # For how to encrypt passwords on a machine before using as a parameter see here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertto-securestring?view=powershell-7
 
+$isDotSourced = $MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq ''
+
+if (-not $isDotSourced)
+{
+    Write-Host "You need to source this script, please run using '. .\upload-positions.ps1'. The 'dot space' has been omitted."
+    Break 1
+}
+
 Write-Host "Install functions"
 
 function API-Post {


### PR DESCRIPTION
If the file is just run and not sourced the install messages are still printed which is confusing for a user, instead output a more helpful message.