### PR TITLE
Update C# script for DataProviderCredentials class to use refinitivId of 1

### DIFF
--- a/Adapptr/Sample-Code&Scripts/C#/DataProviderCredentials.cs
+++ b/Adapptr/Sample-Code&Scripts/C#/DataProviderCredentials.cs
@@ -24,8 +24,7 @@ namespace FundAppsScripts.Scripts
             var username = _adapptrConfig.Username;
             var password = _adapptrConfig.Password;
 
-            //data providers ids can be obtained from a GET /v2/dataproviders. You will need to fill Id with the value of the data vendor you are using
-            var refinitivId = _adapptrConfig.RefinitivConfig.Id;
+            var refinitivId = 1;
             // set your username
             var refinitivUsername = _adapptrConfig.RefinitivConfig.Username;
             // set your password


### PR DESCRIPTION
This is given in the table in [the documentation](https://github.com/fundapps/TechDocs/blob/main/Adapptr/versions/v2.md#data-provider-credentials-post-v2configurationdataprovidersprovideridcredentials), and the old endpoint no longer exists so should not be referenced.